### PR TITLE
Matching with Build buttons at build.particle.io

### DIFF
--- a/lib/spark-dev.coffee
+++ b/lib/spark-dev.coffee
@@ -165,13 +165,13 @@ module.exports =
     @flashButton = @toolBar.addButton
       icon: 'flash'
       callback: 'spark-dev:flash-cloud'
-      tooltip: 'Compile in cloud and upload code using cloud'
+      tooltip: 'Flash'
       iconset: 'ion'
       priority: 51
     @compileButton = @toolBar.addButton
       icon: 'android-cloud-done'
       callback: 'spark-dev:compile-cloud'
-      tooltip: 'Compile in cloud and show errors if any'
+      tooltip: 'Verify'
       iconset: 'ion'
       priority: 52
 
@@ -188,7 +188,7 @@ module.exports =
     @coreButton = @toolBar.addButton
       icon: 'pinpoint'
       callback: 'spark-dev:select-device'
-      tooltip: 'Select which device you want to work on'
+      tooltip: 'Devices'
       iconset: 'ion'
       priority: 55
     @wifiButton = @toolBar.addButton


### PR DESCRIPTION
Hi,
do you think it makes sense to rename these buttons to match the name they have in build.particle.io?

This change was intended to rename "Compile in cloud and upload code using cloud" to "Upload code using cloud" since this is the behaviour I observe while using the toolbar.
But then I checked what is presented in Build, and wondered why not update the buttons to match it?

thank you
Gustavo.