### PR TITLE
match button tooltip with behavior

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -169,7 +169,7 @@ module.exports =
     @flashButton = @toolBar.addButton
       icon: 'flash'
       callback: "#{@packageName()}:flash-cloud"
-      tooltip: 'Compile in cloud and upload code using cloud'
+      tooltip: 'Flash code using cloud'
       iconset: 'ion'
       priority: 51
     @compileButton = @toolBar.addButton


### PR DESCRIPTION
From my observations the button in DEV that says "Compile in cloud and then upload code using cloud" does not seem to be doing the "Compile in cloud" part. It seems to be flashing the code previously compiled and does not take latest changes.
This is the reason why I'm proposing this change.
thanks