### PR TITLE
:package: :arrow_up: Update tool-bar package provider service

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "consumedServices": {
     "status-bar": {
       "versions": {
-        "^1.0.0": "consumeStatusBar"
+        "^0 || ^1": "consumeStatusBar"
       }
     },
     "console-panel": {


### PR DESCRIPTION
The [Tool Bar package](https://atom.io/packages/tool-bar) is going to release a new version after a complete overhaul of it's underlying code. The new version requires that the Tool Bar consumed service semver is updated too. This PR addresses that issue.

There are some changes to the API, but it looks like your plugin isn't affected. Of course it's recommended to test these changes.

Ref suda/tool-bar#141