### PR TITLE
Add warning when attempting to flash via usb

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -729,6 +729,7 @@ module.exports =
     @wifiCredentialsView.show(ssid, security)
 
   tryFlashUsb: -> @projectRequired =>
+    atom.notifications.addWarning 'Flashing via USB from Particle Dev has not yet been implemented'
     if !atom.commands.registeredCommands["#{@packageName()}-dfu-util:flash-usb"]
       # TODO: Ask for installation
     else


### PR DESCRIPTION
Flashing via USB doesn't currently work, and trying to do so fails
silently. This commit adds a warning to alert the user that the command
is currently non-functional.

Related to #6 
