### PR TITLE
tweaks to deviceRequired

### DIFF
--- a/lib/views/select-core-view.coffee
+++ b/lib/views/select-core-view.coffee
@@ -18,8 +18,9 @@ class SelectCoreView extends SelectView
     @spark = null
     @requestErrorHandler = null
 
-  show: =>
+  show: (next=null) =>
     @setItems []
+    @next = next
     @setLoading 'Loading devices...'
     @loadCores()
     super
@@ -42,6 +43,7 @@ class SelectCoreView extends SelectView
     @hide()
     atom.commands.dispatch @workspaceElement, "#{packageName()}:update-core-status"
     atom.commands.dispatch @workspaceElement, "#{packageName()}:update-menu"
+    @next(item) if @next
 
   getFilterKey: ->
     'name'


### PR DESCRIPTION
when a device is required, the pervious behaviour was to show the user a blue notification box telling them to select a device.  The user would have to find the Particle | Select Device... menu, choose it, select a device from the device list, and then perform the operation they tried doing initially again. 

this PR tries to relieve the user a bit by
- adding a "Select Device..." button to the notification prompt that appears
- the prompt disappears after 5 seconds in case the user really doesn't care (same behaviour as before)
- on clicking "Select Device..." the devices selection dialog is shown
- the user may choose a device or choose to close the select device dialog
- if they choose a device, then the initial operation invoked is executed (e.g. compile/flash)

