### PR TITLE
map compile job files to local files

### DIFF
--- a/lib/views/compile-errors-view.coffee
+++ b/lib/views/compile-errors-view.coffee
@@ -23,6 +23,11 @@ class CompileErrorsView extends SelectView
   fixInoFile: (filename) ->
     fs ?= require 'fs-plus'
     path ?= require 'path'
+    # this logic is borken...can't always assume we can infer the path
+    # if the file exist locally, assume it's good
+    # the view shouldn't be fixing up the filename paths...;-)
+    if fs.existsSync(filename)
+      return filename
 
     rootPath = atom.project.getPaths()[0]
     files = fs.listTreeSync rootPath


### PR DESCRIPTION
reverses the server -> local mapping in error messages so that the correct path is displayed in the error message view and opened when clicked.

This is a band-aid. Ideally all the path mapping functionality should be hidden behind a JS API (or the Compile Service endpoint itself) so that external code is not aware that there is even a separate server filesystem namespace for the compile job. 

E.g. the list of files is given for the compile job and the JS/REST API figures out the logical root, maps cpp files back to corresponding ino files and hides any transforms done by the compile service. (Moving root files into `src`, and similarly for copied libraries.)

