### PR TITLE
adds analytics

### DIFF
--- a/lib/contexts/analytics.js
+++ b/lib/contexts/analytics.js
@@ -1,33 +1,17 @@
 'use babel';
-const pipeline = require('when/pipeline');
-import pkg from '../../package.json';
+import {analytics} from 'particle-commands'
 
 /**
  * Creates the context object for command execution.
  */
 
-/**
- * Retrieves the unique ID for the current logged in user.
- */
-function trackingUser() {
-	// todo - fetch from `v1/user` endpoint
-	return Promise.resolve({id: 'dev-test-user'});
+function commandContext(settings, apiClient, pkg = require('../../package.json')) {
+	const tool = { name: 'dev', version: pkg.version };
+	const api = { key: 'DQN7XEETeBoQSFbPTlkOE8X01vyDeSRT' }; //settings.get('trackingApiKey') };
+	const trackingIdentity = settings.fetchUpdate('trackingIdentity');
+	return analytics.buildContext({ tool, api, trackingIdentity, apiClient });
 }
 
-function commandContext() {
-	// todo - allow the API key to be overridden in the environment so that CLI use during development/testing
-	// is tracked against a distinct source
-	return pipeline([
-			trackingUser,
-			(user) => {
-			return {
-				user,
-				tool: { name: 'dev', version: pkg.version },
-				api: { key: 'DQN7XEETeBoQSFbPTlkOE8X01vyDeSRT' }
-			}
-		}
-	]);
-}
 
 export {
 	commandContext

--- a/lib/contexts/analytics.js
+++ b/lib/contexts/analytics.js
@@ -1,0 +1,34 @@
+'use babel';
+const pipeline = require('when/pipeline');
+import pkg from '../../package.json';
+
+/**
+ * Creates the context object for command execution.
+ */
+
+/**
+ * Retrieves the unique ID for the current logged in user.
+ */
+function trackingUser() {
+	// todo - fetch from `v1/user` endpoint
+	return Promise.resolve({id: 'dev-test-user'});
+}
+
+function commandContext() {
+	// todo - allow the API key to be overridden in the environment so that CLI use during development/testing
+	// is tracked against a distinct source
+	return pipeline([
+			trackingUser,
+			(user) => {
+			return {
+				user,
+				tool: { name: 'dev', version: pkg.version },
+				api: { key: 'DQN7XEETeBoQSFbPTlkOE8X01vyDeSRT' }
+			}
+		}
+	]);
+}
+
+export {
+	commandContext
+};

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -954,7 +954,7 @@ module.exports =
       atom.commands.dispatch @workspaceElement, "#{@packageName()}-dfu-util:flash-usb"
 
   analyticsContext: ->
-    @analytics.commandContext()
+    @analytics.commandContext @profileManager, @profileManager.apiClient
 
   runParticleCommand: (site, command) ->
     contextPromise = @analyticsContext()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -53,9 +53,11 @@ module.exports =
   consolePanelDefer: whenjs.defer()
 
   packageName: require './utils/package-helper'
+  analytics: null
 
   activate: (state) ->
     # Require modules on activation
+    @analytics ?= require './contexts/analytics'
     @StatusView ?= require './views/status-bar-view'
     @SettingsHelper ?= require './utils/settings-helper'
     @MenuManager ?= require './utils/menu-manager'
@@ -950,3 +952,10 @@ module.exports =
       # TODO: Ask for installation
     else
       atom.commands.dispatch @workspaceElement, "#{@packageName()}-dfu-util:flash-usb"
+
+  analyticsContext: ->
+    @analytics.commandContext()
+
+  runParticleCommand: (site, command) ->
+    contextPromise = @analyticsContext()
+    contextPromise.then((context) => site.run(command, context))

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gcc-output-parser": "^0.0.3",
     "glob": "^4.2.1",
     "jquery": "^2.0.0",
+    "node-analytics": "^1.0.1",
     "particle-dev-spec-stubs": "git://github.com/spark/particle-dev-spec-stubs.git#v0.0.2",
     "particle-dev-views": "git://github.com/spark/particle-dev-views.git#v0.1.0",
     "particle-library-manager": "^0.1.11",
@@ -72,8 +73,10 @@
     "babel-register": "^6.24.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
+    "coffeelint": "^1.16.0",
     "mocha": "^3.2.0",
-    "sinon": "^2.1.0",
+    "sinon": "1.17.7",
+    "sinon-as-promised": "^4.0.3",
     "sinon-chai": "^2.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "particle-dev-spec-stubs": "git://github.com/spark/particle-dev-spec-stubs.git#v0.0.2",
     "particle-dev-views": "git://github.com/spark/particle-dev-views.git#v0.1.0",
     "particle-library-manager": "^0.1.11",
+    "particle-commands": "git://github.com/spark/particle-commands.git#feature/metrics",
     "request": "*",
     "semver": "^5.3.0",
     "serialport": "git://github.com/suda/node-serialport.git#release/4.0.1",
@@ -63,7 +64,7 @@
     },
     "particle-dev-profiles": {
       "versions": {
-        "^0.0.1": "consumeProfiles"
+        "^0.0.2": "consumeProfiles"
       }
     }
   },

--- a/test/contexts/analytics.spec.js
+++ b/test/contexts/analytics.spec.js
@@ -1,0 +1,20 @@
+import {expect} from '../test-setup';
+import {commandContext} from '../../lib/contexts/analytics';
+
+
+describe('analytics', () => {
+
+	it('has user.id', () => {
+		return expect(commandContext()).to.eventually.have.property('user').to.have.property('id').to.be.ok;
+	});
+
+	it('has api.key', () => {
+		return expect(commandContext()).to.eventually.have.property('api').to.have.property('key').to.be.ok;
+	});
+
+	it('has tool.name', () => {
+		return expect(commandContext()).to.eventually.have.property('tool').to.have.property('name').to.eql('dev');
+	});
+
+
+});

--- a/test/contexts/compilation.spec.js
+++ b/test/contexts/compilation.spec.js
@@ -1,10 +1,3 @@
-'use babel';
-
-import sinon from 'sinon';
-import sinonChai from 'sinon-chai';
-import chai from 'chai';
-chai.use(sinonChai);
-
 import {expect} from 'chai';
 import path from 'path';
 

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -1,0 +1,18 @@
+// Set up the Mocha test framework with the Chai assertion library and
+// the testdouble library for mocks and stubs (previously Sinon mock library)
+
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+import 'sinon-as-promised';
+
+export {
+	chai,
+	sinon,
+	expect
+};


### PR DESCRIPTION
adds `runParticleCommand` to the core service so that individual commands can hook into the tool context (used for injecting analytics deets.)